### PR TITLE
Removed reliance on Beta 0.17 version of the OM tool

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -134,10 +134,10 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
-      trigger: true
-      passed: [config-opsman]
     - get: pcfawsops-terraform-state-get
     - get: tool-om
+      trigger: true
+      passed: [config-opsman]
   - task: config-director
     file: aws-concourse/tasks/config-director.yml
     params:
@@ -162,9 +162,9 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
+    - get: tool-om
       trigger: true
       passed: [config-director]
-    - get: tool-om
   - task: deploy-director
     file: aws-concourse/tasks/deploy-director.yml
     params:
@@ -176,10 +176,10 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
-      trigger: true
-      passed: [deploy-director]
     - get: pcf-pipelines
     - get: tool-om
+      trigger: true
+      passed: [deploy-director]
       params:
         globs: [om-linux]
     - get: stemcell-downloader
@@ -205,8 +205,6 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
-      trigger: true
-      passed: [import-stemcell]
     - get: ert-concourse
     - get: pivnet-elastic-runtime
       passed: [import-stemcell]
@@ -214,6 +212,8 @@ jobs:
         globs:
         - "*pivotal"
     - get: tool-om
+      trigger: true
+      passed: [import-stemcell]
       params:
         globs:
         - "om-linux"
@@ -231,12 +231,12 @@ jobs:
   - aggregate:
     - get: ert-concourse
     - get: tool-om
+      trigger: true
+      passed: [upload-ert]
       params:
         globs:
         - "om-linux"
     - get: aws-concourse
-      trigger: true
-      passed: [upload-ert]
     - get: pcfawsops-terraform-state-get
 
   - task: prepare-rds
@@ -280,10 +280,10 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
-      trigger: true
-      passed: [configure-ert]
     - get: ert-concourse
     - get: tool-om
+      trigger: true
+      passed: [configure-ert]
       params:
         globs:
         - "om-linux"

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -146,7 +146,7 @@ jobs:
       OPSMAN_PASSWORD: {{OPSMAN_PASSWORD}}
       AWS_TEMPLATE: "c0-aws-base"
       AWS_KEY_NAME: {{TF_VAR_aws_key_name}}
-      PEM: {{PEM}}
+      PEM: {{PEM_ESCAPED}}
       AWS_REGION: {{TF_VAR_aws_region}}
       S3_ENDPOINT: {{S3_ENDPOINT}}
       ert_subnet_reserved_ranges_z1: {{ert_subnet_reserved_ranges_z1}}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -242,7 +242,7 @@ jobs:
   - task: prepare-rds
     file: aws-concourse/tasks/prepare-rds.yml
     params:
-      PEM: {{PEM}}
+      PEM: {{PEM_ESCAPED}}
       ERT_DOMAIN: {{ERT_DOMAIN}}
 
   - task: configure-json

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -51,7 +51,7 @@ resources:
 - name: ert-concourse
   type: git
   source:
-    uri: https://github.com/jtgammon/ert-concourse.git
+    uri: https://github.com/c0-ops/ert-concourse.git
     branch: master
 
 - name: pcf-pipelines

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -45,7 +45,7 @@ resources:
   source:
     api_token: {{PIVNET_TOKEN}}
     product_slug: elastic-runtime
-    product_version: 1\.9\..*
+    product_version: 1\.10\..*
     sort_by: semver
 
 - name: ert-concourse

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -134,8 +134,6 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
-      trigger: true
-      passed: [config-opsman]
     - get: pcfawsops-terraform-state-get
     - get: tool-om
   - task: config-director
@@ -162,8 +160,6 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
-      trigger: true
-      passed: [config-director]
     - get: tool-om
   - task: deploy-director
     file: aws-concourse/tasks/deploy-director.yml

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -134,6 +134,8 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
+      trigger: true
+      passed: [config-opsman]
     - get: pcfawsops-terraform-state-get
     - get: tool-om
   - task: config-director
@@ -207,6 +209,7 @@ jobs:
       passed: [import-stemcell]
     - get: ert-concourse
     - get: pivnet-elastic-runtime
+      passed: [import-stemcell]
       params:
         globs:
         - "*pivotal"

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -51,7 +51,7 @@ resources:
 - name: ert-concourse
   type: git
   source:
-    uri: https://github.com/c0-ops/ert-concourse.git
+    uri: https://github.com/jtgammon/ert-concourse.git
     branch: master
 
 - name: pcf-pipelines
@@ -160,6 +160,8 @@ jobs:
   plan:
   - aggregate:
     - get: aws-concourse
+      trigger: true
+      passed: [config-director]
     - get: tool-om
   - task: deploy-director
     file: aws-concourse/tasks/deploy-director.yml
@@ -205,7 +207,6 @@ jobs:
       passed: [import-stemcell]
     - get: ert-concourse
     - get: pivnet-elastic-runtime
-      passed: [import-stemcell]
       params:
         globs:
         - "*pivotal"

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -10,7 +10,7 @@ resources:
   type: git
   source:
     branch: master
-    uri: https://github.com/pivotal-cf/aws-concourse.git
+    uri: https://github.com/jtgammon/aws-concourse.git
 
 - name: pcfawsops-terraform-state-put
   type: s3

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,13 +39,6 @@ resources:
     repository: om
     access_token: {{GITHUB_TOKEN}}
 
-- name: tool-om-beta
-  type: github-release
-  source:
-    user: c0-ops
-    repository: om
-    access_token: {{GITHUB_TOKEN}}
-
 - name: pivnet-elastic-runtime
   type: pivnet
   check_every: 4h
@@ -144,9 +137,7 @@ jobs:
       trigger: true
       passed: [config-opsman]
     - get: pcfawsops-terraform-state-get
-    - get: tool-om-beta
-      globs: [om-linux]
-      version: { tag: '0.17-beta.0' }
+    - get: tool-om
   - task: config-director
     file: aws-concourse/tasks/config-director.yml
     params:

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -11,9 +11,9 @@ do
   `echo "$line" | awk '{print "export "$1"="$3}'`
 done < <(terraform output)
 
-export AWS_ACCESS_KEY_ID=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^id | awk '{print $3}'`
-export AWS_SECRET_ACCESS_KEY=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^secret | awk '{print $3}'`
-export RDS_PASSWORD=`terraform state show aws_db_instance.pcf_rds | grep ^password | awk '{print $3}'`
+#export AWS_ACCESS_KEY_ID=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^id | awk '{print $3}'`
+#export AWS_SECRET_ACCESS_KEY=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^secret | awk '{print $3}'`
+#export RDS_PASSWORD=`terraform state show aws_db_instance.pcf_rds | grep ^password | awk '{print $3}'`
 
 cd $CWD
 
@@ -26,7 +26,7 @@ sudo chmod 755 /usr/local/bin/om-linux
 IAAS_CONFIGURATION=$(cat <<-EOF
 {
 "access_key_id": "${AWS_ACCESS_KEY_ID}",
-"secret_access_key": "${AWS_SECRET_ACCESS_KEY}",
+"secret_access_key": "${AWS_SECRET_ACCESS_KEY_ID}",
 "vpc_id": "${vpc_id}",
 "security_group": "${pcf_security_group}",
 "key_pair_name": "${AWS_KEY_NAME}",

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -39,79 +39,81 @@ EOF
 
 NETWORK_CONFIGURATION=$(cat <<-EOF
 {
-      "Name": "deployment",
-      "ServiceNetwork": false,
-      "Subnets": [
+  "icmp_checks_enabled": false,
+  "networks": [
+      {
+      "name": "deployment",
+      "subnets": [
         {
-          "Name": "${ert_subnet_id_az1}",
+          "iaas_identifier": "${ert_subnet_id_az1}",
           "cidr": "${ert_subnet_cidr_az1}",
           "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z1}",
           "dns": "${dns}",
           "gateway": "${ert_subnet_gw_az1}",
-          "availability_zones": "${az1}"
+          "availability_zones": [  "${az1}"  ]
         },
         {
-          "Name": "${ert_subnet_id_az2}",
+          "iaas_identifier": "${ert_subnet_id_az2}",
           "cidr": "${ert_subnet_cidr_az2}",
           "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z2}",
           "dns": "${dns}",
           "gateway": "${ert_subnet_gw_az1}",
-          "availability_zones": "${az2}"
+          "availability_zones": [  "${az2}"  ]
         },
         {
-          "Name": "${ert_subnet_id_az3}",
+          "iaas_identifier": "${ert_subnet_id_az3}",
           "cidr": "${ert_subnet_cidr_az3}",
           "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z3}",
           "dns": "${DNS}",
           "gateway": "${ert_subnet_gw_az1}",
-          "availability_zones": "${az3}"
+          "availability_zones": [  "${az3}"  ]
         }
       ]
     },
     {
-      "Name": "infrastructure",
-      "ServiceNetwork": false,
-      "Subnets": [
+      "name": "infrastructure",
+      "subnets": [
         {
-          "Name": "${infra_subnet_id_az1}",
+          "iaas_identifier": "${infra_subnet_id_az1}",
           "cidr": "${infra_subnet_cidr_az1}",
           "reserved_ip_ranges": "${infra_subnet_reserved_ranges_z1}",
           "dns": "${dns}",
           "gateway": "${infra_subnet_gw_az1}",
-          "availability_zones": "${az1}"
+          "availability_zones": [   "${az1}"   ]
         }
       ]
     },
     {
-      "Name": "services",
-      "ServiceNetwork": false,
-      "Subnets": [
+      "name": "services",
+      "subnets": [
         {
-          "Name": "${services_subnet_id_az1}",
+          "iaas_identifier": "${services_subnet_id_az1}",
           "cidr": "${services_subnet_cidr_az1}",
           "reserved_ip_ranges": "${services_subnet_reserved_ranges_z1}",
           "dns": "${dns}",
           "gateway": "${services_subnet_gw_az1}",
-          "availability_zones": "${az1}"
+          "availability_zones": [   "${az1}"   ]
         },
         {
-          "Name": "${services_subnet_id_az2}",
+          "iaas_identifier": "${services_subnet_id_az2}",
           "cidr": "${services_subnet_cidr_az2}",
           "reserved_ip_ranges": "${services_subnet_reserved_ranges_z2}",
           "dns": "${dns}",
           "gateway": "${services_subnet_gw_az2}",
-          "availability_zones": "${az2}"
+          "availability_zones": [   "${az2}"   ]
         },
         {
-          "Name": "${services_subnet_id_az3}",
+          "iaas_identifier": "${services_subnet_id_az3}",
           "cidr": "${services_subnet_cidr_az3}",
           "reserved_ip_ranges": "${services_subnet_reserved_ranges_z3}",
           "dns": "${dns}",
           "gateway": "${services_subnet_gw_az3}",
-          "availability_zones": "${az3}"
+          "availability_zones": [   "${az3}"   ]
         }
       ]
     }
+  ]
+}
 EOF
 )
 

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -16,74 +16,128 @@ export AWS_SECRET_ACCESS_KEY=`terraform state show aws_iam_access_key.pcf_iam_us
 export RDS_PASSWORD=`terraform state show aws_db_instance.pcf_rds | grep ^password | awk '{print $3}'`
 
 cd $CWD
-# Set JSON Config Template and inster Concourse Parameter Values
-json_file_path="aws-concourse/json-opsman/${AWS_TEMPLATE}"
-json_file_template="${json_file_path}/opsman-template.json"
-json_file="${json_file_path}/opsman.json"
-
-cp ${json_file_template} ${json_file}
 
 export S3_ESCAPED=${S3_ENDPOINT//\//\\/}
 
-perl -pi -e "s/{{aws_vpc_id}}/${vpc_id}/g" ${json_file}
-perl -pi -e "s/{{aws_sg_id}}/${pcf_security_group}/g" ${json_file}
-perl -pi -e "s/{{aws_keypair_name}}/${AWS_KEY_NAME}/g" ${json_file}
-perl -pi -e "s/{{aws_region}}/${AWS_REGION}/g" ${json_file}
-perl -pi -e "s/{{s3_endpoint}}/${S3_ESCAPED}/g" ${json_file}
-perl -pi -e "s/{{s3_bucket}}/${s3_pcf_bosh}/g" ${json_file}
-perl -pi -e "s/{{rds_host}}/${db_host}/g" ${json_file}
-perl -pi -e "s/{{rds_user}}/${db_username}/g" ${json_file}
-perl -pi -e "s/{{rds_database}}/${db_database}/g" ${json_file}
-perl -pi -e "s/{{aws_az1}}/${az1}/g" ${json_file}
-perl -pi -e "s/{{aws_az2}}/${az2}/g" ${json_file}
-perl -pi -e "s/{{aws_az3}}/${az3}/g" ${json_file}
-perl -pi -e "s/{{vpc_dns}}/${dns}/g" ${json_file}
-
-perl -pi -e "s/{{deployment_subnet_1}}/${ert_subnet_id_az1}/g" ${json_file}
-perl -pi -e "s|{{deployment_subnet_1_cidr}}|${ert_subnet_cidr_az1}|g" ${json_file}
-perl -pi -e "s/{{deployment_subnet_1_reserved}}/${ert_subnet_reserved_ranges_z1}/g" ${json_file}
-perl -pi -e "s/{{deployment_subnet_1_gw}}/${ert_subnet_gw_az1}/g" ${json_file}
-
-perl -pi -e "s/{{deployment_subnet_2}}/${ert_subnet_id_az2}/g" ${json_file}
-perl -pi -e "s|{{deployment_subnet_2_cidr}}|${ert_subnet_cidr_az2}|g" ${json_file}
-perl -pi -e "s/{{deployment_subnet_2_reserved}}/${ert_subnet_reserved_ranges_z2}/g" ${json_file}
-perl -pi -e "s/{{deployment_subnet_2_gw}}/${ert_subnet_gw_az2}/g" ${json_file}
-
-perl -pi -e "s/{{deployment_subnet_3}}/${ert_subnet_id_az3}/g" ${json_file}
-perl -pi -e "s|{{deployment_subnet_3_cidr}}|${ert_subnet_cidr_az3}|g" ${json_file}
-perl -pi -e "s/{{deployment_subnet_3_reserved}}/${ert_subnet_reserved_ranges_z3}/g" ${json_file}
-perl -pi -e "s/{{deployment_subnet_3_gw}}/${ert_subnet_gw_az3}/g" ${json_file}
-
-perl -pi -e "s/{{services_subnet_1}}/${services_subnet_id_az1}/g" ${json_file}
-perl -pi -e "s|{{services_subnet_1_cidr}}|${services_subnet_cidr_az1}|g" ${json_file}
-perl -pi -e "s/{{services_subnet_1_reserved}}/${services_subnet_reserved_ranges_z1}/g" ${json_file}
-perl -pi -e "s/{{services_subnet_1_gw}}/${services_subnet_gw_az1}/g" ${json_file}
-
-perl -pi -e "s/{{services_subnet_2}}/${services_subnet_id_az2}/g" ${json_file}
-perl -pi -e "s|{{services_subnet_2_cidr}}|${services_subnet_cidr_az2}|g" ${json_file}
-perl -pi -e "s/{{services_subnet_2_reserved}}/${services_subnet_reserved_ranges_z2}/g" ${json_file}
-perl -pi -e "s/{{services_subnet_2_gw}}/${services_subnet_gw_az2}/g" ${json_file}
-
-perl -pi -e "s/{{services_subnet_3}}/${services_subnet_id_az3}/g" ${json_file}
-perl -pi -e "s|{{services_subnet_3_cidr}}|${services_subnet_cidr_az3}|g" ${json_file}
-perl -pi -e "s/{{services_subnet_3_reserved}}/${services_subnet_reserved_ranges_z3}/g" ${json_file}
-perl -pi -e "s/{{services_subnet_3_gw}}/${services_subnet_gw_az3}/g" ${json_file}
-
-perl -pi -e "s/{{infra_subnet}}/${infra_subnet_id_az1}/g" ${json_file}
-perl -pi -e "s|{{infra_subnet_cidr}}|${infra_subnet_cidr_az1}|g" ${json_file}
-perl -pi -e "s/{{infra_subnet_reserved}}/${infra_subnet_reserved_ranges_z1}/g" ${json_file}
-perl -pi -e "s/{{infra_subnet_gw}}/${infra_subnet_gw_az1}/g" ${json_file}
-
-echo "=============================================================================================="
-echo "Configuring Director @ https://opsman.$ERT_DOMAIN ..."
-cat $json_file
-echo "=============================================================================================="
 
 sudo cp tool-om-beta/om-linux /usr/local/bin
 sudo chmod 755 /usr/local/bin/om-linux
 
-om-linux -t https://opsman.$ERT_DOMAIN -u "$OPSMAN_USER" -p "$OPSMAN_PASSWORD" -k \
-  aws -a $AWS_ACCESS_KEY_ID \
-  -s $AWS_SECRET_ACCESS_KEY \
-  -d $RDS_PASSWORD \
-  -p "$PEM" -c "$(cat ${json_file})"
+IAAS_CONFIGURATION=$(cat <<-EOF
+{
+"access_key_id": ${AWS_ACCESS_KEY_ID},
+"secret_access_key": ${AWS_SECRET_ACCESS_KEY},
+"vpc_id": "${vpc_id}",
+"security_group": "${pcf_security_group}",
+"key_pair_name": "${AWS_KEY_NAME}",
+"ssh_private_key": "$PEM",
+"region": "${AWS_REGION}",
+"encrypted": false
+}
+EOF
+)
+
+NETWORK_CONFIGURATION=$(cat <<-EOF
+{
+      "Name": "deployment",
+      "ServiceNetwork": false,
+      "Subnets": [
+        {
+          "Name": "${ert_subnet_id_az1}",
+          "cidr": "${ert_subnet_cidr_az1}",
+          "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z1}",
+          "dns": "${dns}",
+          "gateway": "${ert_subnet_gw_az1}",
+          "availability_zones": "${az1}"
+        },
+        {
+          "Name": "${ert_subnet_id_az2}",
+          "cidr": "${ert_subnet_cidr_az2}",
+          "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z2}",
+          "dns": "${dns}",
+          "gateway": "${ert_subnet_gw_az1}",
+          "availability_zones": "${az2}"
+        },
+        {
+          "Name": "${ert_subnet_id_az3}",
+          "cidr": "${ert_subnet_cidr_az3}",
+          "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z3}",
+          "dns": "${DNS}",
+          "gateway": "${ert_subnet_gw_az1}",
+          "availability_zones": "${az3}"
+        }
+      ]
+    },
+    {
+      "Name": "infrastructure",
+      "ServiceNetwork": false,
+      "Subnets": [
+        {
+          "Name": "${infra_subnet_id_az1}",
+          "cidr": "${infra_subnet_cidr_az1}",
+          "reserved_ip_ranges": "${infra_subnet_reserved_ranges_z1}",
+          "dns": "${dns}",
+          "gateway": "${infra_subnet_gw_az1}",
+          "availability_zones": "${az1}"
+        }
+      ]
+    },
+    {
+      "Name": "services",
+      "ServiceNetwork": false,
+      "Subnets": [
+        {
+          "Name": "${services_subnet_id_az1}",
+          "cidr": "${services_subnet_cidr_az1}",
+          "reserved_ip_ranges": "${services_subnet_reserved_ranges_z1}",
+          "dns": "${dns}",
+          "gateway": "${services_subnet_gw_az1}",
+          "availability_zones": "${az1}"
+        },
+        {
+          "Name": "${services_subnet_id_az2}",
+          "cidr": "${services_subnet_cidr_az2}",
+          "reserved_ip_ranges": "${services_subnet_reserved_ranges_z2}",
+          "dns": "${dns}",
+          "gateway": "${services_subnet_gw_az2}",
+          "availability_zones": "${az2}"
+        },
+        {
+          "Name": "${services_subnet_id_az3}",
+          "cidr": "${services_subnet_cidr_az3}",
+          "reserved_ip_ranges": "${services_subnet_reserved_ranges_z3}",
+          "dns": "${dns}",
+          "gateway": "${services_subnet_gw_az3}",
+          "availability_zones": "${az3}"
+        }
+      ]
+    }
+EOF
+)
+
+
+NETWORK_ASSIGNMENT=$(cat <<-EOF
+{
+  "singleton_availability_zone": "${az1}",
+  "network": "infrastructure"
+}
+EOF
+)
+
+echo "=============================================================================================="
+echo "Configuring Director Infrastructure @ https://opsman.$ERT_DOMAIN ..."
+echo "=============================================================================================="
+
+om-linux -t https://opsman.$ERT_DOMAIN -u "$OPSMAN_USER" -p "$OPSMAN_PASSWORD" -k configure-bosh -i "$IAAS_CONFIGURATION"
+
+echo "=============================================================================================="
+echo "Configuring Director Networks @ https://opsman.$ERT_DOMAIN ..."
+echo "=============================================================================================="
+
+om-linux -t https://opsman.$ERT_DOMAIN -u "$OPSMAN_USER" -p "$OPSMAN_PASSWORD" -k configure-bosh -n "$NETWORK_CONFIGURATION"
+
+echo "=============================================================================================="
+echo "Configuring Director Network Assignments @ https://opsman.$ERT_DOMAIN ..."
+echo "=============================================================================================="
+
+om-linux -t https://opsman.$ERT_DOMAIN -u "$OPSMAN_USER" -p "$OPSMAN_PASSWORD" -k configure-bosh -na "$NETWORK_ASSIGNMENT"

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -11,9 +11,9 @@ do
   `echo "$line" | awk '{print "export "$1"="$3}'`
 done < <(terraform output)
 
-#export AWS_ACCESS_KEY_ID=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^id | awk '{print $3}'`
-#export AWS_SECRET_ACCESS_KEY=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^secret | awk '{print $3}'`
-#export RDS_PASSWORD=`terraform state show aws_db_instance.pcf_rds | grep ^password | awk '{print $3}'`
+export AWS_ACCESS_KEY_ID=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^id | awk '{print $3}'`
+export AWS_SECRET_ACCESS_KEY=`terraform state show aws_iam_access_key.pcf_iam_user_access_key | grep ^secret | awk '{print $3}'`
+export RDS_PASSWORD=`terraform state show aws_db_instance.pcf_rds | grep ^password | awk '{print $3}'`
 
 cd $CWD
 
@@ -26,7 +26,7 @@ sudo chmod 755 /usr/local/bin/om-linux
 IAAS_CONFIGURATION=$(cat <<-EOF
 {
 "access_key_id": "${AWS_ACCESS_KEY_ID}",
-"secret_access_key": "${AWS_SECRET_ACCESS_KEY_ID}",
+"secret_access_key": "${AWS_SECRET_ACCESS_KEY}",
 "vpc_id": "${vpc_id}",
 "security_group": "${pcf_security_group}",
 "key_pair_name": "${AWS_KEY_NAME}",

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -57,15 +57,15 @@ NETWORK_CONFIGURATION=$(cat <<-EOF
           "cidr": "${ert_subnet_cidr_az2}",
           "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z2}",
           "dns": "${dns}",
-          "gateway": "${ert_subnet_gw_az1}",
+          "gateway": "${ert_subnet_gw_az2}",
           "availability_zones": [  "${az2}"  ]
         },
         {
           "iaas_identifier": "${ert_subnet_id_az3}",
           "cidr": "${ert_subnet_cidr_az3}",
           "reserved_ip_ranges": "${ert_subnet_reserved_ranges_z3}",
-          "dns": "${DNS}",
-          "gateway": "${ert_subnet_gw_az1}",
+          "dns": "${dns}",
+          "gateway": "${ert_subnet_gw_az3}",
           "availability_zones": [  "${az3}"  ]
         }
       ]

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -41,7 +41,7 @@ AZ_CONFIGURATION=$(cat <<-EOF
 {
 "availability_zones": [
     {"name": "${az1}"},
-    {"name": "${az2}"}
+    {"name": "${az2}"},
     {"name": "${az3}"}
   ]
 }

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -20,7 +20,7 @@ cd $CWD
 export S3_ESCAPED=${S3_ENDPOINT//\//\\/}
 
 
-sudo cp tool-om-beta/om-linux /usr/local/bin
+sudo cp tool-om/om-linux /usr/local/bin
 sudo chmod 755 /usr/local/bin/om-linux
 
 IAAS_CONFIGURATION=$(cat <<-EOF

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -37,6 +37,24 @@ IAAS_CONFIGURATION=$(cat <<-EOF
 EOF
 )
 
+AZ_CONFIGURATION=$(cat <<-EOF
+{
+"availability_zones": [
+    {"name": "${az1}"},
+    {"name": "${az2}"}
+    {"name": "${az3}"}
+  ]
+}
+EOF
+)
+
+NTP_CONFIGURATION=$(cat <<-EOF
+{
+"ntp_servers_string": "0.amazon.pool.ntp.org"
+}
+EOF
+)
+
 NETWORK_CONFIGURATION=$(cat <<-EOF
 {
   "icmp_checks_enabled": false,
@@ -131,6 +149,18 @@ echo "Configuring Director Infrastructure @ https://opsman.$ERT_DOMAIN ..."
 echo "=============================================================================================="
 
 om-linux -t https://opsman.$ERT_DOMAIN -u "$OPSMAN_USER" -p "$OPSMAN_PASSWORD" -k configure-bosh -i "$IAAS_CONFIGURATION"
+
+echo "=============================================================================================="
+echo "Configuring Director NTP @ https://opsman.$ERT_DOMAIN ..."
+echo "=============================================================================================="
+
+om-linux -t https://opsman.$ERT_DOMAIN -u "$OPSMAN_USER" -p "$OPSMAN_PASSWORD" -k configure-bosh -d "$NTP_CONFIGURATION"
+
+echo "=============================================================================================="
+echo "Configuring Director AZs @ https://opsman.$ERT_DOMAIN ..."
+echo "=============================================================================================="
+
+om-linux -t https://opsman.$ERT_DOMAIN -u "$OPSMAN_USER" -p "$OPSMAN_PASSWORD" -k configure-bosh -a "$AZ_CONFIGURATION"
 
 echo "=============================================================================================="
 echo "Configuring Director Networks @ https://opsman.$ERT_DOMAIN ..."

--- a/scripts/config-director.sh
+++ b/scripts/config-director.sh
@@ -25,8 +25,8 @@ sudo chmod 755 /usr/local/bin/om-linux
 
 IAAS_CONFIGURATION=$(cat <<-EOF
 {
-"access_key_id": ${AWS_ACCESS_KEY_ID},
-"secret_access_key": ${AWS_SECRET_ACCESS_KEY},
+"access_key_id": "${AWS_ACCESS_KEY_ID}",
+"secret_access_key": "${AWS_SECRET_ACCESS_KEY}",
 "vpc_id": "${vpc_id}",
 "security_group": "${pcf_security_group}",
 "key_pair_name": "${AWS_KEY_NAME}",

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -13,4 +13,4 @@ echo "==========================================================================
 om-linux --target https://opsman.$pcf_ert_domain -k \
        --username "$pcf_opsman_admin" \
        --password "$pcf_opsman_admin_passwd" \
-  apply-changes -i true
+  apply-changes

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -10,7 +10,7 @@ echo "==========================================================================
 
 # Apply Changes in Opsman
 
-om-linux --target https://opsman.$pcf_ert_domain -k -i true \
+om-linux --target https://opsman.$pcf_ert_domain -k -i TRUE \
        --username "$pcf_opsman_admin" \
        --password "$pcf_opsman_admin_passwd" \
   apply-changes

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -10,7 +10,7 @@ echo "==========================================================================
 
 # Apply Changes in Opsman
 
-om-linux --target https://opsman.$pcf_ert_domain -k -i \
+om-linux --target https://opsman.$pcf_ert_domain -k -i true \
        --username "$pcf_opsman_admin" \
        --password "$pcf_opsman_admin_passwd" \
   apply-changes

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -10,7 +10,7 @@ echo "==========================================================================
 
 # Apply Changes in Opsman
 
-om-linux --target https://opsman.$pcf_ert_domain -k \
+om-linux --target https://opsman.$pcf_ert_domain -k -i \
        --username "$pcf_opsman_admin" \
        --password "$pcf_opsman_admin_passwd" \
   apply-changes

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -10,7 +10,7 @@ echo "==========================================================================
 
 # Apply Changes in Opsman
 
-om-linux --target https://opsman.$pcf_ert_domain -k -i TRUE \
+om-linux --target https://opsman.$pcf_ert_domain -k -i="TRUE" \
        --username "$pcf_opsman_admin" \
        --password "$pcf_opsman_admin_passwd" \
   apply-changes

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -10,7 +10,7 @@ echo "==========================================================================
 
 # Apply Changes in Opsman
 
-om-linux --target https://opsman.$pcf_ert_domain -k -i="TRUE" \
+om-linux --target https://opsman.$pcf_ert_domain -k \
        --username "$pcf_opsman_admin" \
        --password "$pcf_opsman_admin_passwd" \
-  apply-changes
+  apply-changes -i true

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -10,7 +10,7 @@ echo "==========================================================================
 
 # Apply Changes in Opsman
 
-om-linux --target https://opsman.$pcf_ert_domain -k -i \
+om-linux --target https://opsman.$pcf_ert_domain -k \
        --username "$pcf_opsman_admin" \
        --password "$pcf_opsman_admin_passwd" \
   apply-changes

--- a/tasks/config-director.yml
+++ b/tasks/config-director.yml
@@ -8,6 +8,6 @@ image_resource:
 inputs:
   - name: aws-concourse
   - name: pcfawsops-terraform-state-get
-  - name: tool-om-beta
+  - name: tool-om
 run:
   path: aws-concourse/scripts/config-director.sh


### PR DESCRIPTION
I was using this pipeline at a Landmark POC, and the config-director job was not working properly with PCF v1.9. I modified config-director script to use the regular syntax for the OM tool to do the director configuration, instead of the beta version of the tool that was used previously. This has been tested and worked.

AWS configure-bosh commands that I used are documented here:
https://github.com/pivotal-cf/om/blob/master/docs/configure-bosh/aws.md